### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/lib/makeup/formatters/html/html_formatter.ex
+++ b/lib/makeup/formatters/html/html_formatter.ex
@@ -10,9 +10,16 @@ defmodule Makeup.Formatters.HTML.HTMLFormatter do
   """, [:escaped_value, :css_class, :meta])
 
   def format_token({tag, meta, value}) do
-    escaped_value = HtmlEntities.encode(value)
+    escaped_value = escape(value)
     css_class = Makeup.Token.Utils.css_class_for_token_type(tag)
     render_token(escaped_value, css_class, meta)
+  end
+
+  defp escape(string) do
+    escape_map = [{"&", "&amp;"}, {"<", "&lt;"}, {">", "&gt;"}, {~S("), "&quot;"}]
+    Enum.reduce escape_map, string, fn {pattern, escape}, acc ->
+      String.replace(acc, pattern, escape)
+    end
   end
 
   def format_inner(tokens) do

--- a/lib/makeup/styles/html.ex
+++ b/lib/makeup/styles/html.ex
@@ -132,8 +132,6 @@ defmodule Makeup.Styles.HTML do
       literal: nil
     ]
 
-    use ExConstructor
-
     @doc """
     A `TokenStyle` is considered empty if all its fields are `nil`.
 
@@ -194,12 +192,12 @@ defmodule Makeup.Styles.HTML do
     TODO: Add examples
     """
     def from_string(str) do
-      str
-      |> String.split()
-      |> Enum.map(&to_attr/1)
-      |> Enum.filter(fn x -> x end)
-      |> Enum.into(%{})
-      |> TokenStyle.new
+      attrs =
+        str
+        |> String.split()
+        |> Enum.map(&to_attr/1)
+        |> Enum.filter(fn x -> x end)
+      struct(TokenStyle, attrs)
     end
   end
 

--- a/lib/makeup/token/utils.ex
+++ b/lib/makeup/token/utils.ex
@@ -1,7 +1,4 @@
 defmodule Makeup.Token.Utils do
-
-  use Const
-
   require Makeup.Token.TokenTypes
   alias Makeup.Token.TokenTypes, as: Tok
 
@@ -97,19 +94,24 @@ defmodule Makeup.Token.Utils do
       {Tok.generic_traceback, "gt"}]}
   ]
 
-  
+
+  @precedence Hierarchy.hierarchy_to_precedence(@hierarchy)
   @token_to_class_map Hierarchy.style_to_class_map(@hierarchy)
+  @standard_token_types Map.keys(@token_to_class_map)
 
-  const precedence, do:
-    Hierarchy.hierarchy_to_precedence(@hierarchy)
-  const token_to_class_map, do:
-    @token_to_class_map
-  const standard_token_types, do:
-    Map.keys(@token_to_class_map)
-
-
-  def css_class_for_token_type(token_type) do
-   Map.get(@token_to_class_map, token_type, nil)
+  def precedence do
+    @precedence
   end
 
+  def token_to_class_map do
+    @token_to_class_map
+  end
+
+  def standard_token_types do
+    @standard_token_types
+  end
+
+  def css_class_for_token_type(token_type) do
+    Map.get(@token_to_class_map, token_type, nil)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -46,9 +46,6 @@ defmodule Makeup.Mixfile do
   defp deps do
     [
       {:ex_spirit, "~> 0.3.0"},
-      {:ex_const, "~> 0.1.0"},
-      {:exconstructor, "~> 1.1.0"},
-      {:html_entities, "~> 0.3.0"},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false}
       #{:ex_doc, path: "../ex_doc", only: :dev, runtime: false}
     ]


### PR DESCRIPTION
* html_entities can be replaced by 6 LOC (which are also more efficient)
* ExConstructor can be replaced by `struct/2` (you can also use `struct!` if you want to check for fields
* `const` can be replaced by module attributes