### PR TITLE
Depend on NimbleParsec v0.4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule Makeup.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:nimble_parsec, "~> 0.4"},
+      {:nimble_parsec, "~> 0.4.0"},
       {:stream_data, "~> 0.4.2", only: [:dev, :test]}
     ]
   end


### PR DESCRIPTION
For now, it is better to always depend on ~> 0.x.0 because we can introduce breaking changes in minor releases until v1.0 is out. In fact, makeup is just broken with nimble_parsec 0.5.0. :) Can you please do a new release? Thank you!