### PR TITLE
Update to nimble_parsec 0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ by adding `makeup` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:makeup, "~> 0.4.0"}
+    {:makeup, "~> 0.5"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Makeup.Mixfile do
   use Mix.Project
 
-  @version "0.5.5"
+  @version "0.6.0"
   @url "https://github.com/tmbb/makeup"
 
   def project do
@@ -58,7 +58,7 @@ defmodule Makeup.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:nimble_parsec, "~> 0.4.0"},
+      {:nimble_parsec, "~> 0.5"},
       {:stream_data, "~> 0.4.2", only: [:dev, :test]}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule Makeup.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:nimble_parsec, "~> 0.5"},
+      {:nimble_parsec, "~> 0.5.0"},
       {:stream_data, "~> 0.4.2", only: [:dev, :test]}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,6 @@
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "stream_data": {:hex, :stream_data, "0.4.2", "fa86b78c88ec4eaa482c0891350fcc23f19a79059a687760ddcf8680aac2799b", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
Updated to support `nimble_parsec` 0.5.  I changed the dependency to just `0.5` so perhaps you might wish to change that to `0.5.0` in line with @josevalim's earlier recommendation.  Tests are passing.  Note an update to `makeup_elixir` is also required and is in a separate PR.