### PR TITLE
Add support for custom highlight tag

### DIFF
--- a/lib/makeup.ex
+++ b/lib/makeup.ex
@@ -56,8 +56,14 @@ defmodule Makeup do
         opts -> opts
       end
 
+    formatter_options =
+      case options[:formatter_options] do
+        nil -> []
+        opts -> opts
+      end
+
     tokens = apply(lexer, :lex, [source, lexer_options])
-    apply(HTMLFormatter, :format_inner_as_binary, [tokens])
+    apply(HTMLFormatter, :format_inner_as_binary, [tokens, formatter_options])
   end
 
   @doc """

--- a/lib/makeup/formatters/html/html_formatter.ex
+++ b/lib/makeup/formatters/html/html_formatter.ex
@@ -5,7 +5,7 @@ defmodule Makeup.Formatters.HTML.HTMLFormatter do
 
   @group_highlight_js "lib/makeup/formatters/html/scripts/group_highlighter_javascript.js" |> File.read!
 
-  defp render_token(escaped_value, css_class, highlight_tag, meta) do
+  defp render_token(escaped_value, css_class, meta, highlight_tag) do
     group_id = meta[:group_id]
     selectable = Map.get(meta, :selectable, [])
 
@@ -35,7 +35,7 @@ defmodule Makeup.Formatters.HTML.HTMLFormatter do
   def format_token({tag, meta, value}, highlight_tag) do
     escaped_value = escape(value)
     css_class = Makeup.Token.Utils.css_class_for_token_type(tag)
-    render_token(escaped_value, css_class, highlight_tag, meta)
+    render_token(escaped_value, css_class, meta, highlight_tag)
   end
 
   defp escape_for(?&), do: "&amp;"

--- a/test/makeup_test.exs
+++ b/test/makeup_test.exs
@@ -1,4 +1,45 @@
 defmodule MakeupTest do
   use ExUnit.Case
   doctest Makeup
+
+  defmodule FakeLexer do
+    @behaviour Makeup.Lexer
+
+    @impl true
+    def root_element(_), do: raise "Not implemented"
+
+    @impl true
+    def root(_), do: raise "Not implemented"
+
+    @impl true
+    def postprocess(_, _), do: raise "Not implemented"
+
+    @impl true
+    def match_groups(_, _), do: raise "Not implemented"
+
+    @impl true
+    def lex("CompiledWithDocs.example", _lexer_options) do
+      [
+        {:name_class, %{language: :elixir}, ["C", "ompiledWithDocs"]},
+        {:operator, %{language: :elixir}, "."},
+        {:name, %{language: :elixir}, "example"}
+      ]
+    end
+  end
+
+  describe "highlight_inner_html" do
+    test "hightlight using default tag <span>" do
+      assert Makeup.highlight_inner_html("CompiledWithDocs.example", lexer: FakeLexer) ==
+        ~S(<span class="nc">CompiledWithDocs</span><span class="o">.</span><span class="n">example</span>)
+    end
+
+    test "hightlight using custom tag <samp>" do
+      formatter_options = [highlight_tag: "samp"]
+      options = [lexer: FakeLexer, formatter_options: formatter_options]
+
+      assert Makeup.highlight_inner_html("CompiledWithDocs.example", options) ==
+        ~S(<samp class="nc">CompiledWithDocs</samp><samp class="o">.</samp><samp class="n">example</samp>)
+    end
+  end
+
 end


### PR DESCRIPTION
This PR adds a new option `:highlight_tag` to `Makeup.highlight_inner_html/2`. I'm not sure this is the path you wanted me to take. Let me know if you have something else in mind.

Closes #21 and #22.