### PR TITLE
Add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+language: elixir
+
+elixir: '1.9'
+otp_release: '22.0'
+
+stages:
+  - test
+
+jobs:
+  include:
+    - stage: test
+
+    - elixir: 1.6
+      otp_release: 20.3
+    - elixir: 1.9
+      otp_release: 20.3
+    - elixir: 1.9
+      otp_release: 21.3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Makeup
+[![Build Status](https://travis-ci.org/tmbb/makeup.svg?branch=master)](https://travis-ci.org/tmbb/makeup)
 
 ## Introduction
 


### PR DESCRIPTION
### Implementation

- Adds a `travis.yml`
- Adds the README badge showing the status of the master branch
- ~~Run formatter in the codebase so we are able to check for it on CI (can be a separated PR if needed since it's a **really long diff** :smile:)~~ Will be done in another PR

### Additional things :warning:

I couldn't test against `elixir` `1.4` because of an error that I had with Erlang/OTP `19.*` regarding Unicode and an error on `stream_data`

<details>
<summary> More details of the errors here </summary>
<br>
Being more specific, the Unicode error was variable named <code>josé</code> in the tests and the <code>stream_data</code> one is because it expects an <code>ex_unit</code> seed to be provided and before elixir 1.6 <code>ex_unit</code> does not generate a random default seed
</details>

So I thought of two options: 
- Fix the errors to be able to support `erlang 19.*` and `elixir 1.4` that will be basically two things:
  - Remove the Unicode variable
  - Generate ourselves a random seed if not provided for `ex_unit`
  - There's a POC [here](https://github.com/mracos/makeup/compare/add-travis-ci...mracos:support-elixir-1-4-and-erlang-19)

- Or drop support for `erlang 19.*` and `elixir 1.4` by updating the minimum version that we support of `elixir` to `1.6`
  - Why `1.6`? Because it's the minimum version that [dropped support to `erlang 19.*`](https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp) and when it was introduced the [`ex_unit` default random seed feature](https://github.com/elixir-lang/elixir/blob/v1.6/CHANGELOG.md#exunit-1)

On this PR I went with the simplest one that is not testing against elixir `1.4` and `Erlang/OTP 19.*` but I'm happy to help with whatever option you may see fit.  :smile:

Not forgetting that we will have to enable the repository in https://travis-ci.org for it to build and test our branches/PRs.