### PR TITLE
Terminal formatter

### DIFF
--- a/lib/makeup.ex
+++ b/lib/makeup.ex
@@ -25,7 +25,7 @@ defmodule Makeup do
       end
 
     tokens = apply(lexer, :lex, [source, lexer_options])
-    apply(formatter, :format_as_binary, [tokens])
+    apply(formatter, :format_as_binary, [tokens, options])
   end
 
   defp fetch_lexer(options) do

--- a/lib/makeup/formatters/terminal/terminal_formatter.ex
+++ b/lib/makeup/formatters/terminal/terminal_formatter.ex
@@ -1,0 +1,121 @@
+defmodule Makeup.Formatters.Terminal.TerminalFormatter do
+  @moduledoc """
+  Turns a list of tokens into the appropiate sequence of ANSI escape codes,
+  suitable to be printed in a terminal.
+  """
+
+  alias Makeup.Styles.HTML.StyleMap
+  alias IO.ANSI
+
+  # For some reason the IO.ANSI module only accepts 8 bit ANSI colors. So this
+  # is a mostly copy pasted version of the ANSI.color/3 that deals with 24 bit
+  # colors.
+  defp color([r, g, b]), do: color(r, g, b)
+
+  defp color(r, g, b) when r in 0..255 and g in 0..255 and b in 0..255 do
+    "\e[38;2;#{r};#{g};#{b}m"
+  end
+
+  defp color_background([r, g, b]), do: color_background(r, g, b)
+
+  defp color_background(r, g, b) when r in 0..255 and g in 0..255 and b in 0..255 do
+    "\e[48;2;#{r};#{g};#{b}m"
+  end
+
+  # Parses the hex color string into a list of integers.
+  defp hex_values("#" <> colors) do
+    colors
+    |> String.codepoints()
+    |> Enum.chunk_every(2)
+    |> Enum.map(fn hex_color_list ->
+      hex_color_list
+      |> Enum.join()
+      |> String.to_integer(16)
+    end)
+  end
+
+  # Transforms `Makeup.Styles.HTML.Style` attributes into ANSI codes. Because
+  # escape codes are always inline, each attribute is translated into a tuple
+  # of two ANSI codes; one for setting it and one for resetting the default
+  # value.
+  defp get_ansi(style_attr, defaults)
+
+  defp get_ansi({_, nil}, _defaults), do: []
+
+  defp get_ansi({:background_color, c}, defaults),
+    do: [
+      {
+        c |> hex_values() |> color_background(),
+        Map.get(defaults, :background_color)
+      }
+    ]
+
+  defp get_ansi({:color, c}, _defaults),
+    do: [{c |> hex_values() |> color(), ANSI.default_color()}]
+
+  defp get_ansi({:font_style, sty}, _defaults) when sty in ["italic", "oblique"],
+    do: [{ANSI.italic(), ANSI.not_italic()}]
+
+  defp get_ansi({:font_weight, "bold"}, _defaults), do: [{ANSI.bright(), ANSI.normal()}]
+
+  defp get_ansi({:text_decoration, "underline"}, _defaults),
+    do: [{ANSI.underline(), ANSI.no_underline()}]
+
+  defp get_ansi({_, _}, _defaults), do: []
+
+  defp escape(v) when is_list(v), do: Enum.map(v, &escape/1)
+  defp escape(v) when is_integer(v), do: <<v::utf8>>
+  defp escape(v) when is_bitstring(v), do: v
+
+  defp escape(v) do
+    raise "Found `#{inspect(v)}` inside what should be an iolist"
+  end
+
+  @doc """
+  Format a single token into an IO list of ANSI escape codes.
+  """
+  def format_token({tag, _meta, val}, styles, defaults) do
+    {set_ansi, reset_ansi} =
+      styles
+      |> Map.get(tag)
+      |> Map.to_list()
+      |> Enum.flat_map(&get_ansi(&1, defaults))
+      |> Enum.unzip()
+
+    [
+      set_ansi,
+      escape(val),
+      reset_ansi
+    ]
+  end
+
+  @doc """
+  Turns a list of tokens into an IO list of ANSI escape codes.
+  """
+  def format_as_iolist(tokens, opts \\ []) do
+    style_name = Keyword.get(opts, :style, :default_style)
+    style = apply(StyleMap, style_name, [])
+    default_bg = style.background_color |> hex_values() |> color_background()
+
+    style_defaults = %{
+      background_color: default_bg
+    }
+
+    [
+      ANSI.reset(),
+      default_bg,
+      Enum.map(tokens, &format_token(&1, style.styles, style_defaults)),
+      ANSI.reset()
+    ]
+  end
+
+  @doc """
+  Turns a list of tokens into a string with the appropriate ANSI escape codes.
+  This string is suitable to be printed in a terminal.
+  """
+  def format_as_binary(tokens, opts \\ []) do
+    tokens
+    |> format_as_iolist(opts)
+    |> IO.iodata_to_binary()
+  end
+end

--- a/test/terminal_formatter_test.exs
+++ b/test/terminal_formatter_test.exs
@@ -1,0 +1,24 @@
+defmodule MakeupTest.Lexer.TerminalFormatterTest do
+  use ExUnit.Case, async: true
+  import ExUnitProperties
+  alias Makeup.Formatters.Terminal.TerminalFormatter
+
+  test "encode ASCII character" do
+    check all c <- StreamData.integer(1..16666) do
+      char = << c :: utf8 >>
+      formatted =
+        TerminalFormatter.format_as_binary([{:string, %{}, c}])
+        |> String.codepoints()
+
+      assert char in formatted
+    end
+  end
+
+  test "raise exception when token is not an iolist" do
+    msg = "Found `%{}` inside what should be an iolist"
+
+    assert_raise RuntimeError, msg, fn ->
+      assert TerminalFormatter.format_as_binary([{:string, %{}, %{}}])
+    end
+  end
+end


### PR DESCRIPTION
Hi!

As a nice weekend project I implemented a terminal formatter for the Makeup Styles using ANSI escape codes.

By the structure of the project, I guess the styles were designed only for CSS, but most fields translate nicely into ANSI codes. The only field I didn't understand how to use was the `TokenStyle.literal` field.

If this gets merged, maybe I could restructure the styles to be more back-end agnostic.