### PR TITLE
Add one dark theme style

### DIFF
--- a/lib/makeup/styles/html/style_map.ex
+++ b/lib/makeup/styles/html/style_map.ex
@@ -787,6 +787,42 @@ defmodule Makeup.Styles.HTML.StyleMap do
   """
   def native_style, do: @native_style
 
+  @one_dark_style Style.make_style(
+    short_name: "one_dark",
+    long_name: "One Dark Style",
+    background_color: "#282c34",
+    highlight_color: "#31353f",
+    styles: %{
+      :punctuation => "#ABB2BF",
+      :keyword => "#C678DD",
+      :keyword_constant => "#E5C07B",
+      :keyword_declaration => "#C678DD",
+      :keyword_namespace => "#C678DD",
+      :keyword_reserved => "#C678DD",
+      :keyword_type => "#E5C07B",
+      :name => "#C4CAD6",
+      :name_attribute => "#E06C75",
+      :name_builtin => "#E5C07B",
+      :name_class => "#E06C75",
+      :name_constant => "#61AFEF",
+      :name_function => "bold #61AFEF",
+      :name_function_magic => "bold #56B6C2",
+      :name_other => "#E06C75",
+      :name_tag => "#E06C75",
+      :name_decorator => "#61AFEF",
+      :string => "#98C379",
+      :string_symbol => "#61AFEF",
+      :number => "#D19A66",
+      :operator => "#56B6C2",
+      :comment => "#8C92A3"
+    }
+  )
+
+  @doc """
+  The *one_dark* style. Example [here](https://elixir-makeup.github.io/makeup_demo/elixir.html#one_dark).
+  """
+  def one_dark_style, do: @one_dark_style
+
   @paraiso_dark_style Style.make_style(
                         short_name: "paraiso_dark",
                         long_name: "ParaisoDark Style",


### PR DESCRIPTION
The colors are based on the theme used by [livebook](https://github.com/livebook-dev/livebook/blob/4899767673111832a5cd472555692b07b3e8282d/assets/js/hooks/cell_editor/live_editor/theme.js) - the objective is to have the same look as livebook as much as possible, which is a popular tool and I think it would be useful to have makeup generating the same style.

I hope it's fine to open a PR since the Dracula theme was [added manually](https://github.com/elixir-makeup/makeup/pull/59) as well. And for context I'd use those colors in blog posts for dockyard.com if that helps.

Displayed by makeup:
<img width="624" alt="makeup" src="https://github.com/elixir-makeup/makeup/assets/36407/fd1fe27a-b677-44b4-8502-b56b52c70b76">

And displayed by livebook:
<img width="1076" alt="livebook" src="https://github.com/elixir-makeup/makeup/assets/36407/eb6f9a36-5601-4e3d-84d0-7307925a9580">
